### PR TITLE
feat: MCP server in Common Lisp (issue #22)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install SBCL
+        run: sudo apt-get update && sudo apt-get install -y sbcl
+
+      - name: Install Quicklisp
+        run: |
+          curl -fsSL -o quicklisp.lisp https://beta.quicklisp.org/quicklisp.lisp
+          sbcl --non-interactive --load quicklisp.lisp \
+            --eval '(quicklisp-quickstart:install)' \
+            --eval '(sb-ext:exit)'
+
+      - name: Install jonathan
+        run: |
+          sbcl --non-interactive \
+            --eval '(load (merge-pathnames "quicklisp/setup.lisp" (user-homedir-pathname)))' \
+            --eval '(ql:quickload :jonathan)' \
+            --eval '(sb-ext:exit)'
+
+      - name: Test server.lisp loads without errors
+        run: |
+          echo "" | timeout 30 sbcl --script mcp/server.lisp 2>&1 | head -20
+          echo "PASS: server.lisp loaded without errors"
+
+      - name: Test MCP initialize handshake
+        run: |
+          REQUEST='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"0.1.0"}}}'
+          RESPONSE=$(echo "$REQUEST" | timeout 30 sbcl --script mcp/server.lisp 2>/dev/null)
+          echo "Response: $RESPONSE"
+          echo "$RESPONSE" | grep -q '"result"' || { echo "FAIL: no result in response"; exit 1; }
+          echo "$RESPONSE" | grep -q '"protocolVersion"' || { echo "FAIL: no protocolVersion in response"; exit 1; }
+          echo "PASS: MCP initialize handshake successful"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+.PHONY: build/mcp
+
+build/mcp:
+	@command -v sbcl >/dev/null 2>&1 || { echo "ERROR: sbcl not found — install SBCL 2.6+"; exit 1; }
+	@echo "Rhema MCP server ready (interpreted, no compilation needed)."
+	@echo "Run with:  sbcl --script mcp/server.lisp"

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -1,0 +1,184 @@
+# Rhema MCP Server — Integration Guide
+
+The Rhema MCP server exposes a single tool, `rhema_eval`, that evaluates
+Common Lisp expressions inside a persistent SBCL REPL.  Any MCP-capable
+host (VS Code Copilot, OpenCode, Claude Desktop, etc.) can use it.
+
+```
+Host  ──stdio/JSON-RPC──▶  mcp/server.lisp  ──unix socket──▶  /tmp/rhema.sock (SBCL)
+```
+
+---
+
+## 1  Prerequisites
+
+| Requirement | Why |
+|-------------|-----|
+| **SBCL 2.6+** | Runs the persistent REPL and the MCP server |
+| **Quicklisp** | Provides the `jonathan` JSON library used by the MCP server |
+| **`jonathan` loaded via Quicklisp** | `(ql:quickload :jonathan)` — the MCP server imports it at startup |
+| **Rhema socket running** | The MCP server connects to `/tmp/rhema.sock`; without it, every call errors |
+
+Install Quicklisp (if missing):
+
+```bash
+curl -O https://beta.quicklisp.org/quicklisp.lisp
+sbcl --load quicklisp.lisp --eval '(quicklisp-quickstart:install)' --quit
+```
+
+---
+
+## 2  Starting the Rhema socket
+
+The SBCL background process must be running before any MCP client connects.
+Full setup instructions are in [`skills/rhema/SKILL.md`](../skills/rhema/SKILL.md).
+
+Quick start:
+
+```bash
+# Generate init.lisp (discovers library files automatically)
+bash scripts/sbcl-repl.sh generate-init
+
+# Launch SBCL in the background with the generated init
+sbcl --load ~/rhema/init.lisp
+```
+
+Confirm the socket exists:
+
+```bash
+ls -l /tmp/rhema.sock
+```
+
+---
+
+## 3  VS Code Copilot (agent mode)
+
+Create `.vscode/mcp.json` in your project root:
+
+```json
+{
+  "servers": {
+    "rhema": {
+      "type": "stdio",
+      "command": "sbcl",
+      "args": ["--script", "/absolute/path/to/rhema/mcp/server.lisp"]
+    }
+  }
+}
+```
+
+> Replace `/absolute/path/to/rhema` with the actual path to this repo.
+
+In VS Code:
+1. Open Copilot Chat (agent mode).
+2. The `rhema_eval` tool appears in the tool list.
+3. Ask the model to evaluate a Lisp expression — it will call the tool.
+
+---
+
+## 4  OpenCode
+
+Add to `~/.config/opencode/config.json`:
+
+```json
+{
+  "mcpServers": {
+    "rhema": {
+      "command": "sbcl",
+      "args": ["--script", "/absolute/path/to/rhema/mcp/server.lisp"]
+    }
+  }
+}
+```
+
+Restart OpenCode.  The `rhema_eval` tool is available immediately.
+
+---
+
+## 5  Claude Desktop
+
+Add to your Claude Desktop config (`claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "rhema": {
+      "command": "sbcl",
+      "args": ["--script", "/absolute/path/to/rhema/mcp/server.lisp"]
+    }
+  }
+}
+```
+
+Config file locations:
+- **macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Linux:** `~/.config/Claude/claude_desktop_config.json`
+- **Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
+
+Restart Claude Desktop after editing.
+
+---
+
+## 6  Verify it works
+
+In any connected host, ask the model:
+
+> Call rhema_eval with the expression `(+ 1 1)`
+
+Expected response: `2`
+
+Try something stateful to confirm persistence:
+
+> Evaluate `(defvar *counter* 0)` then `(incf *counter*)` twice.
+
+The counter should increment across calls — the REPL state persists.
+
+---
+
+## 7  Troubleshooting
+
+### Socket not running
+
+```
+Error: Failed to connect to /tmp/rhema.sock
+```
+
+The SBCL background process is not running or the socket was not created.
+
+1. Check: `ls /tmp/rhema.sock`
+2. If missing, start the REPL (see [section 2](#2--starting-the-rhema-socket)).
+3. If the file exists but is stale (process died), remove it and restart:
+   ```bash
+   rm /tmp/rhema.sock
+   sbcl --load ~/rhema/init.lisp
+   ```
+
+### Quicklisp not found
+
+```
+Package JONATHAN does not exist.
+```
+
+The MCP server loads `jonathan` via Quicklisp at startup.
+
+1. Ensure Quicklisp is installed: `ls ~/quicklisp/setup.lisp`
+2. If missing, install it (see [section 1](#1--prerequisites)).
+3. Pre-load jonathan once: `sbcl --eval '(load "~/quicklisp/setup.lisp")' --eval '(ql:quickload :jonathan)' --quit`
+
+### MCP server starts but tools don't appear
+
+- Confirm the `--script` path is absolute and correct.
+- Check the host's MCP log output for JSON parse errors.
+- Run the server manually to see startup errors:
+  ```bash
+  sbcl --script mcp/server.lisp
+  ```
+  Then send a test request on stdin:
+  ```json
+  {"jsonrpc":"2.0","id":1,"method":"tools/list"}
+  ```
+
+### Permission denied on socket
+
+`/tmp/rhema.sock` is created with mode `600` (owner-only).  The MCP
+server must run as the same user that started the SBCL REPL.

--- a/mcp/server.lisp
+++ b/mcp/server.lisp
@@ -1,0 +1,395 @@
+;;;; mcp/server.lisp — Rhema MCP server (stdio transport)
+;;;; JSON-RPC 2.0 over stdin/stdout, delegates to /tmp/rhema.sock
+;;;; Run: sbcl --script mcp/server.lisp
+;;;; Zero external dependencies — SBCL built-ins only.
+
+(require :sb-bsd-sockets)
+
+;;; ============================================================
+;;; Minimal JSON parser (handles MCP envelopes only)
+;;; ============================================================
+
+(defun skip-ws (str pos)
+  "Skip whitespace in STR starting at POS."
+  (loop while (and (< pos (length str))
+                   (member (char str pos) '(#\Space #\Tab #\Newline #\Return)))
+        do (incf pos))
+  pos)
+
+(defun parse-json-string (str pos)
+  "Parse a JSON string starting at POS (after opening quote). Returns (values string new-pos)."
+  (assert (char= (char str pos) #\"))
+  (incf pos) ; skip opening "
+  (let ((out (make-array 0 :element-type 'character :adjustable t :fill-pointer 0)))
+    (loop
+      (when (>= pos (length str))
+        (error "Unterminated JSON string"))
+      (let ((ch (char str pos)))
+        (cond
+          ((char= ch #\")
+           (return (values (coerce out 'simple-string) (1+ pos))))
+          ((char= ch #\\)
+           (incf pos)
+           (when (>= pos (length str))
+             (error "Unterminated JSON escape"))
+           (let ((esc (char str pos)))
+             (vector-push-extend
+              (case esc
+                (#\" #\")
+                (#\\ #\\)
+                (#\/ #\/)
+                (#\n #\Newline)
+                (#\r #\Return)
+                (#\t #\Tab)
+                (#\b #\Backspace)
+                (#\f (code-char 12))
+                (#\u
+                 ;; Parse 4-hex-digit unicode escape
+                 (let ((hex (subseq str (1+ pos) (+ pos 5))))
+                   (setf pos (+ pos 4))
+                   (code-char (parse-integer hex :radix 16))))
+                (t esc))
+              out)
+             (incf pos)))
+          (t
+           (vector-push-extend ch out)
+           (incf pos)))))))
+
+(defun parse-json-number (str pos)
+  "Parse a JSON number. Returns (values number new-pos)."
+  (let ((start pos)
+        (has-dot nil))
+    (when (and (< pos (length str)) (char= (char str pos) #\-))
+      (incf pos))
+    (loop while (and (< pos (length str))
+                     (or (digit-char-p (char str pos))
+                         (and (char= (char str pos) #\.) (not has-dot))))
+          do (when (char= (char str pos) #\.)
+               (setf has-dot t))
+             (incf pos))
+    ;; Handle exponent
+    (when (and (< pos (length str))
+               (member (char str pos) '(#\e #\E)))
+      (incf pos)
+      (when (and (< pos (length str))
+                 (member (char str pos) '(#\+ #\-)))
+        (incf pos))
+      (loop while (and (< pos (length str))
+                       (digit-char-p (char str pos)))
+            do (incf pos)))
+    (let ((num-str (subseq str start pos)))
+      (if has-dot
+          (values (read-from-string num-str) pos)
+          (values (parse-integer num-str) pos)))))
+
+(defun parse-json-value (str pos)
+  "Parse a JSON value at POS. Returns (values value new-pos)."
+  (setf pos (skip-ws str pos))
+  (when (>= pos (length str))
+    (error "Unexpected end of JSON"))
+  (let ((ch (char str pos)))
+    (cond
+      ((char= ch #\")
+       (parse-json-string str pos))
+      ((char= ch #\{)
+       (parse-json-object str pos))
+      ((char= ch #\[)
+       (parse-json-array str pos))
+      ((char= ch #\t) ; true
+       (values t (+ pos 4)))
+      ((char= ch #\f) ; false
+       (values nil (+ pos 5)))
+      ((char= ch #\n) ; null
+       (values :null (+ pos 4)))
+      ((or (digit-char-p ch) (char= ch #\-))
+       (parse-json-number str pos))
+      (t (error "Unexpected JSON character ~A at ~D" ch pos)))))
+
+(defun parse-json-object (str pos)
+  "Parse a JSON object. Returns (values alist new-pos)."
+  (assert (char= (char str pos) #\{))
+  (incf pos)
+  (setf pos (skip-ws str pos))
+  (let ((result '()))
+    (when (char= (char str pos) #\})
+      (return-from parse-json-object (values result (1+ pos))))
+    (loop
+      (setf pos (skip-ws str pos))
+      (multiple-value-bind (key new-pos) (parse-json-string str pos)
+        (setf pos (skip-ws str new-pos))
+        (assert (char= (char str pos) #\:))
+        (incf pos)
+        (multiple-value-bind (val val-pos) (parse-json-value str pos)
+          (push (cons key val) result)
+          (setf pos (skip-ws str val-pos))
+          (cond
+            ((char= (char str pos) #\})
+             (return (values (nreverse result) (1+ pos))))
+            ((char= (char str pos) #\,)
+             (incf pos))
+            (t (error "Expected , or } in object"))))))))
+
+(defun parse-json-array (str pos)
+  "Parse a JSON array. Returns (values list new-pos)."
+  (assert (char= (char str pos) #\[))
+  (incf pos)
+  (setf pos (skip-ws str pos))
+  (let ((result '()))
+    (when (char= (char str pos) #\])
+      (return-from parse-json-array (values result (1+ pos))))
+    (loop
+      (multiple-value-bind (val new-pos) (parse-json-value str pos)
+        (push val result)
+        (setf pos (skip-ws str new-pos))
+        (cond
+          ((char= (char str pos) #\])
+           (return (values (nreverse result) (1+ pos))))
+          ((char= (char str pos) #\,)
+           (incf pos))
+          (t (error "Expected , or ] in array")))))))
+
+(defun parse-json (str)
+  "Parse a JSON string into Lisp. Objects become alists, arrays become lists."
+  (multiple-value-bind (val _pos) (parse-json-value str 0)
+    (declare (ignore _pos))
+    val))
+
+(defun json-get (obj key)
+  "Get KEY from a parsed JSON object (alist). KEY is a string."
+  (cdr (assoc key obj :test #'string=)))
+
+;;; ============================================================
+;;; Minimal JSON serializer
+;;; ============================================================
+
+(defun json-escape-string (s)
+  "Escape a Lisp string for JSON output."
+  (with-output-to-string (out)
+    (loop for ch across s do
+      (case ch
+        (#\" (write-string "\\\"" out))
+        (#\\ (write-string "\\\\" out))
+        (#\Newline (write-string "\\n" out))
+        (#\Return (write-string "\\r" out))
+        (#\Tab (write-string "\\t" out))
+        (#\Backspace (write-string "\\b" out))
+        (t
+         (if (< (char-code ch) 32)
+             (format out "\\u~4,'0X" (char-code ch))
+             (write-char ch out)))))))
+
+(defun serialize-json (value)
+  "Serialize a Lisp value to JSON string.
+   Alists with string keys -> objects, lists -> arrays,
+   strings -> strings, numbers -> numbers, t -> true, nil -> false, :null -> null."
+  (cond
+    ((eq value :null) "null")
+    ((eq value t) "true")
+    ((null value) "false")
+    ((stringp value)
+     (format nil "\"~A\"" (json-escape-string value)))
+    ((integerp value)
+     (format nil "~D" value))
+    ((numberp value)
+     (format nil "~F" value))
+    ;; Alist (object) — detect by first element being a cons with string car
+    ((and (consp value) (consp (car value)) (stringp (caar value)))
+     (format nil "{~{~A~^,~}}"
+             (mapcar (lambda (pair)
+                       (format nil "\"~A\":~A"
+                               (json-escape-string (car pair))
+                               (serialize-json (cdr pair))))
+                     value)))
+    ;; List (array)
+    ((listp value)
+     (format nil "[~{~A~^,~}]"
+             (mapcar #'serialize-json value)))
+    (t (format nil "\"~A\"" (json-escape-string (format nil "~A" value))))))
+
+;;; ============================================================
+;;; Socket client — talk to /tmp/rhema.sock
+;;; ============================================================
+
+(defvar *rhema-socket-path* "/tmp/rhema.sock")
+(defvar *rhema-timeout-seconds* 30)
+
+(defun rhema-eval (expression)
+  "Send EXPRESSION to the Rhema socket server and return the delimited result.
+   Returns two values: result-string and error-p."
+  (handler-case
+      (let ((sock (make-instance 'sb-bsd-sockets:local-socket :type :stream)))
+        (unwind-protect
+            (progn
+              (sb-bsd-sockets:socket-connect sock *rhema-socket-path*)
+              (let ((stream (sb-bsd-sockets:socket-make-stream
+                             sock :input t :output t
+                             :buffering :line
+                             :element-type 'character)))
+                (unwind-protect
+                    (progn
+                      ;; Send expression
+                      (write-string expression stream)
+                      (terpri stream)
+                      (force-output stream)
+                      ;; Shutdown write side so server sees EOF
+                      (sb-bsd-sockets:socket-shutdown sock :direction :output)
+                      ;; Read response, extract between delimiters
+                      (let ((lines '())
+                            (capturing nil)
+                            (captured '()))
+                        (loop for line = (read-line stream nil nil)
+                              while line do
+                              (cond
+                                ((string= (string-trim '(#\Space #\Return) line)
+                                          "===RHEMA-BEGIN===")
+                                 (setf capturing t))
+                                ((string= (string-trim '(#\Space #\Return) line)
+                                          "===RHEMA-END===")
+                                 (setf capturing nil)
+                                 ;; Join captured lines
+                                 (push (format nil "~{~A~^~%~}" (nreverse captured))
+                                       lines)
+                                 (setf captured '()))
+                                (capturing
+                                 (push line captured))))
+                        (if lines
+                            (values (format nil "~{~A~^~%~}" (nreverse lines)) nil)
+                            (values "ERROR: No delimited response from Rhema" t))))
+                  (close stream))))
+          (handler-case (sb-bsd-sockets:socket-close sock) (error () nil))))
+    (sb-bsd-sockets:socket-error (c)
+      (values (format nil "ERROR: Cannot connect to ~A — ~A" *rhema-socket-path* c) t))
+    (error (c)
+      (values (format nil "ERROR: ~A" c) t))))
+
+;;; ============================================================
+;;; MCP protocol handlers
+;;; ============================================================
+
+(defvar *mcp-server-name* "rhema-mcp")
+(defvar *mcp-server-version* "0.1.0")
+
+(defun make-jsonrpc-response (id result)
+  "Build a JSON-RPC 2.0 success response alist."
+  `(("jsonrpc" . "2.0")
+    ("id" . ,id)
+    ("result" . ,result)))
+
+(defun make-jsonrpc-error (id code message)
+  "Build a JSON-RPC 2.0 error response alist."
+  `(("jsonrpc" . "2.0")
+    ("id" . ,id)
+    ("error" . (("code" . ,code)
+                ("message" . ,message)))))
+
+(defun handle-initialize (id _params)
+  "Handle initialize request — return server capabilities."
+  (declare (ignore _params))
+  (make-jsonrpc-response id
+    `(("protocolVersion" . "2024-11-05")
+      ("capabilities" . (("tools" . (("listChanged" . ,nil)))))
+      ("serverInfo" . (("name" . ,*mcp-server-name*)
+                       ("version" . ,*mcp-server-version*))))))
+
+(defun handle-tools-list (id _params)
+  "Handle tools/list — return available tools."
+  (declare (ignore _params))
+  (make-jsonrpc-response id
+    `(("tools" .
+       ((("name" . "rhema_eval")
+         ("description" . "Evaluate a Common Lisp expression in the persistent Rhema REPL. The expression is sent to the SBCL process via /tmp/rhema.sock and the result is returned.")
+         ("inputSchema" .
+          (("type" . "object")
+           ("properties" .
+            (("expression" .
+              (("type" . "string")
+               ("description" . "A Common Lisp expression to evaluate")))))
+           ("required" . ("expression"))))))))))
+
+(defun handle-tools-call (id params)
+  "Handle tools/call — dispatch to the requested tool."
+  (let* ((tool-name (json-get params "name"))
+         (arguments (json-get params "arguments")))
+    (cond
+      ((string= tool-name "rhema_eval")
+       (let ((expression (json-get arguments "expression")))
+         (if expression
+             (multiple-value-bind (result errorp) (rhema-eval expression)
+               (make-jsonrpc-response id
+                 `(("content" .
+                    ((("type" . "text")
+                      ("text" . ,result))))
+                   ,@(when errorp
+                       `(("isError" . t))))))
+             (make-jsonrpc-error id -32602 "Missing required argument: expression"))))
+      (t
+       (make-jsonrpc-error id -32602 (format nil "Unknown tool: ~A" tool-name))))))
+
+;;; ============================================================
+;;; Main loop — stdio JSON-RPC transport
+;;; ============================================================
+
+(defun send-response (response)
+  "Serialize and write a JSON-RPC response to stdout."
+  (let ((json (serialize-json response)))
+    (write-string json *standard-output*)
+    (terpri *standard-output*)
+    (force-output *standard-output*)))
+
+(defun process-message (msg)
+  "Dispatch a parsed JSON-RPC message. Returns response or nil for notifications."
+  (let ((method (json-get msg "method"))
+        (id (json-get msg "id"))
+        (params (or (json-get msg "params") '())))
+    (cond
+      ;; Notifications (no id) — don't respond
+      ((and (null id) (string= method "notifications/initialized"))
+       nil)
+      ((and (null id) method)
+       ;; Unknown notification — silently ignore
+       nil)
+      ;; Requests
+      ((string= method "initialize")
+       (handle-initialize id params))
+      ((string= method "tools/list")
+       (handle-tools-list id params))
+      ((string= method "tools/call")
+       (handle-tools-call id params))
+      ;; Unknown method
+      (id
+       (make-jsonrpc-error id -32601 (format nil "Method not found: ~A" method)))
+      (t nil))))
+
+(defun main-loop ()
+  "Read JSON-RPC messages from stdin, dispatch, respond on stdout."
+  ;; Redirect any stray debug output to stderr so stdout stays clean
+  (let ((*error-output* *error-output*)
+        (*trace-output* *error-output*)
+        (*debug-io* (make-two-way-stream *standard-input* *error-output*)))
+    (loop for line = (read-line *standard-input* nil nil)
+          while line do
+          (let ((trimmed (string-trim '(#\Space #\Tab #\Return #\Newline) line)))
+            (unless (string= trimmed "")
+              (handler-case
+                  (let* ((msg (parse-json trimmed))
+                         (response (process-message msg)))
+                    (when response
+                      (send-response response)))
+                (error (c)
+                  ;; Parse error or internal error — send JSON-RPC error
+                  (send-response
+                   (make-jsonrpc-error :null -32700
+                     (format nil "Parse error: ~A" c))))))))))
+
+;; Suppress SBCL startup noise
+(handler-case
+    (progn
+      ;; Log to stderr so MCP host can see it
+      (format *error-output* "rhema-mcp: starting stdio transport~%")
+      (force-output *error-output*)
+      (main-loop)
+      (sb-ext:exit :code 0))
+  (error (c)
+    (format *error-output* "rhema-mcp: fatal error: ~A~%" c)
+    (force-output *error-output*)
+    (sb-ext:exit :code 1)))

--- a/mcp/server.lisp
+++ b/mcp/server.lisp
@@ -1,210 +1,51 @@
 ;;;; mcp/server.lisp — Rhema MCP server (stdio transport)
 ;;;; JSON-RPC 2.0 over stdin/stdout, delegates to /tmp/rhema.sock
 ;;;; Run: sbcl --script mcp/server.lisp
-;;;; Zero external dependencies — SBCL built-ins only.
+;;;; Requires Quicklisp + jonathan for JSON.
 
 (require :sb-bsd-sockets)
 
+;;; Load Quicklisp and jonathan (suppress stdout to keep MCP transport clean)
+(let ((*standard-output* *error-output*))
+  (load (merge-pathnames "quicklisp/setup.lisp" (user-homedir-pathname)))
+  (ql:quickload :jonathan :silent t))
+
 ;;; ============================================================
-;;; Minimal JSON parser (handles MCP envelopes only)
+;;; JSON helpers (jonathan library)
 ;;; ============================================================
-
-(defun skip-ws (str pos)
-  "Skip whitespace in STR starting at POS."
-  (loop while (and (< pos (length str))
-                   (member (char str pos) '(#\Space #\Tab #\Newline #\Return)))
-        do (incf pos))
-  pos)
-
-(defun parse-json-string (str pos)
-  "Parse a JSON string starting at POS (after opening quote). Returns (values string new-pos)."
-  (assert (char= (char str pos) #\"))
-  (incf pos) ; skip opening "
-  (let ((out (make-array 0 :element-type 'character :adjustable t :fill-pointer 0)))
-    (loop
-      (when (>= pos (length str))
-        (error "Unterminated JSON string"))
-      (let ((ch (char str pos)))
-        (cond
-          ((char= ch #\")
-           (return (values (coerce out 'simple-string) (1+ pos))))
-          ((char= ch #\\)
-           (incf pos)
-           (when (>= pos (length str))
-             (error "Unterminated JSON escape"))
-           (let ((esc (char str pos)))
-             (vector-push-extend
-              (case esc
-                (#\" #\")
-                (#\\ #\\)
-                (#\/ #\/)
-                (#\n #\Newline)
-                (#\r #\Return)
-                (#\t #\Tab)
-                (#\b #\Backspace)
-                (#\f (code-char 12))
-                (#\u
-                 ;; Parse 4-hex-digit unicode escape
-                 (let ((hex (subseq str (1+ pos) (+ pos 5))))
-                   (setf pos (+ pos 4))
-                   (code-char (parse-integer hex :radix 16))))
-                (t esc))
-              out)
-             (incf pos)))
-          (t
-           (vector-push-extend ch out)
-           (incf pos)))))))
-
-(defun parse-json-number (str pos)
-  "Parse a JSON number. Returns (values number new-pos)."
-  (let ((start pos)
-        (has-dot nil))
-    (when (and (< pos (length str)) (char= (char str pos) #\-))
-      (incf pos))
-    (loop while (and (< pos (length str))
-                     (or (digit-char-p (char str pos))
-                         (and (char= (char str pos) #\.) (not has-dot))))
-          do (when (char= (char str pos) #\.)
-               (setf has-dot t))
-             (incf pos))
-    ;; Handle exponent
-    (when (and (< pos (length str))
-               (member (char str pos) '(#\e #\E)))
-      (incf pos)
-      (when (and (< pos (length str))
-                 (member (char str pos) '(#\+ #\-)))
-        (incf pos))
-      (loop while (and (< pos (length str))
-                       (digit-char-p (char str pos)))
-            do (incf pos)))
-    (let ((num-str (subseq str start pos)))
-      (if has-dot
-          (values (read-from-string num-str) pos)
-          (values (parse-integer num-str) pos)))))
-
-(defun parse-json-value (str pos)
-  "Parse a JSON value at POS. Returns (values value new-pos)."
-  (setf pos (skip-ws str pos))
-  (when (>= pos (length str))
-    (error "Unexpected end of JSON"))
-  (let ((ch (char str pos)))
-    (cond
-      ((char= ch #\")
-       (parse-json-string str pos))
-      ((char= ch #\{)
-       (parse-json-object str pos))
-      ((char= ch #\[)
-       (parse-json-array str pos))
-      ((char= ch #\t) ; true
-       (values t (+ pos 4)))
-      ((char= ch #\f) ; false
-       (values nil (+ pos 5)))
-      ((char= ch #\n) ; null
-       (values :null (+ pos 4)))
-      ((or (digit-char-p ch) (char= ch #\-))
-       (parse-json-number str pos))
-      (t (error "Unexpected JSON character ~A at ~D" ch pos)))))
-
-(defun parse-json-object (str pos)
-  "Parse a JSON object. Returns (values alist new-pos)."
-  (assert (char= (char str pos) #\{))
-  (incf pos)
-  (setf pos (skip-ws str pos))
-  (let ((result '()))
-    (when (char= (char str pos) #\})
-      (return-from parse-json-object (values result (1+ pos))))
-    (loop
-      (setf pos (skip-ws str pos))
-      (multiple-value-bind (key new-pos) (parse-json-string str pos)
-        (setf pos (skip-ws str new-pos))
-        (assert (char= (char str pos) #\:))
-        (incf pos)
-        (multiple-value-bind (val val-pos) (parse-json-value str pos)
-          (push (cons key val) result)
-          (setf pos (skip-ws str val-pos))
-          (cond
-            ((char= (char str pos) #\})
-             (return (values (nreverse result) (1+ pos))))
-            ((char= (char str pos) #\,)
-             (incf pos))
-            (t (error "Expected , or } in object"))))))))
-
-(defun parse-json-array (str pos)
-  "Parse a JSON array. Returns (values list new-pos)."
-  (assert (char= (char str pos) #\[))
-  (incf pos)
-  (setf pos (skip-ws str pos))
-  (let ((result '()))
-    (when (char= (char str pos) #\])
-      (return-from parse-json-array (values result (1+ pos))))
-    (loop
-      (multiple-value-bind (val new-pos) (parse-json-value str pos)
-        (push val result)
-        (setf pos (skip-ws str new-pos))
-        (cond
-          ((char= (char str pos) #\])
-           (return (values (nreverse result) (1+ pos))))
-          ((char= (char str pos) #\,)
-           (incf pos))
-          (t (error "Expected , or ] in array")))))))
 
 (defun parse-json (str)
-  "Parse a JSON string into Lisp. Objects become alists, arrays become lists."
-  (multiple-value-bind (val _pos) (parse-json-value str 0)
-    (declare (ignore _pos))
-    val))
+  "Parse a JSON string into a hash table using jonathan."
+  (jonathan:parse str :as :hash-table))
 
 (defun json-get (obj key)
-  "Get KEY from a parsed JSON object (alist). KEY is a string."
-  (cdr (assoc key obj :test #'string=)))
+  "Get KEY from a parsed JSON object (hash table). KEY is a string."
+  (when obj (gethash key obj)))
 
-;;; ============================================================
-;;; Minimal JSON serializer
-;;; ============================================================
-
-(defun json-escape-string (s)
-  "Escape a Lisp string for JSON output."
-  (with-output-to-string (out)
-    (loop for ch across s do
-      (case ch
-        (#\" (write-string "\\\"" out))
-        (#\\ (write-string "\\\\" out))
-        (#\Newline (write-string "\\n" out))
-        (#\Return (write-string "\\r" out))
-        (#\Tab (write-string "\\t" out))
-        (#\Backspace (write-string "\\b" out))
-        (t
-         (if (< (char-code ch) 32)
-             (format out "\\u~4,'0X" (char-code ch))
-             (write-char ch out)))))))
-
-(defun serialize-json (value)
-  "Serialize a Lisp value to JSON string.
-   Alists with string keys -> objects, lists -> arrays,
-   strings -> strings, numbers -> numbers, t -> true, nil -> false, :null -> null."
+(defun alist-to-json-value (value)
+  "Recursively convert alist-based response structures for JSON serialization.
+   Alists with string keys become hash tables; lists become arrays."
   (cond
-    ((eq value :null) "null")
-    ((eq value t) "true")
-    ((null value) "false")
-    ((stringp value)
-     (format nil "\"~A\"" (json-escape-string value)))
-    ((integerp value)
-     (format nil "~D" value))
-    ((numberp value)
-     (format nil "~F" value))
+    ((eq value :false) :false)
+    ((eq value :null) :null)
+    ((eq value t) t)
+    ((null value) :null)
+    ((stringp value) value)
+    ((numberp value) value)
     ;; Alist (object) — detect by first element being a cons with string car
     ((and (consp value) (consp (car value)) (stringp (caar value)))
-     (format nil "{~{~A~^,~}}"
-             (mapcar (lambda (pair)
-                       (format nil "\"~A\":~A"
-                               (json-escape-string (car pair))
-                               (serialize-json (cdr pair))))
-                     value)))
+     (let ((ht (make-hash-table :test 'equal)))
+       (dolist (pair value)
+         (setf (gethash (car pair) ht) (alist-to-json-value (cdr pair))))
+       ht))
     ;; List (array)
     ((listp value)
-     (format nil "[~{~A~^,~}]"
-             (mapcar #'serialize-json value)))
-    (t (format nil "\"~A\"" (json-escape-string (format nil "~A" value))))))
+     (mapcar #'alist-to-json-value value))
+    (t value)))
+
+(defun serialize-json (value)
+  "Serialize a Lisp value to a JSON string using jonathan."
+  (jonathan:to-json (alist-to-json-value value)))
 
 ;;; ============================================================
 ;;; Socket client — talk to /tmp/rhema.sock
@@ -287,7 +128,7 @@
   (declare (ignore _params))
   (make-jsonrpc-response id
     `(("protocolVersion" . "2024-11-05")
-      ("capabilities" . (("tools" . (("listChanged" . ,nil)))))
+      ("capabilities" . (("tools" . (("listChanged" . :false)))))
       ("serverInfo" . (("name" . ,*mcp-server-name*)
                        ("version" . ,*mcp-server-version*))))))
 
@@ -340,7 +181,7 @@
   "Dispatch a parsed JSON-RPC message. Returns response or nil for notifications."
   (let ((method (json-get msg "method"))
         (id (json-get msg "id"))
-        (params (or (json-get msg "params") '())))
+        (params (or (json-get msg "params") (make-hash-table))))
     (cond
       ;; Notifications (no id) — don't respond
       ((and (null id) (string= method "notifications/initialized"))

--- a/scripts/init.lisp.template
+++ b/scripts/init.lisp.template
@@ -1,11 +1,11 @@
 ;;;; Rhema init.lisp — auto-generated from scripts/init.lisp.template
 ;;;; Do not edit by hand. Run: ~/github.com/exokomodo/rhema/scripts/sbcl-repl.sh generate-init
 
+;;;; Quicklisp (must load before library files that may use ql:quickload)
+(load "{{HOME}}/quicklisp/setup.lisp")
+
 ;;;; Library files (auto-discovered from LIBRARY_DIR)
 {{LIBRARY_LOADS}}
-
-;;;; Quicklisp
-(load "{{HOME}}/quicklisp/setup.lisp")
 
 ;;;; Swank — persistent SLIME/SLY server on port 4005
 (ql:quickload :swank :silent t)

--- a/scripts/sbcl-repl.sh
+++ b/scripts/sbcl-repl.sh
@@ -48,8 +48,8 @@ generate_init() {
         # Fallback: inline generation if template missing
         {
             echo ";;;; Rhema init.lisp — auto-generated (template not found)"
-            echo "${library_loads}"
             echo "(load \"$HOME/quicklisp/setup.lisp\")"
+            echo "${library_loads}"
             echo "(ql:quickload :swank :silent t)"
             echo "(swank:create-server :port 4005 :dont-close t)"
             echo "(rhema-server:start)"


### PR DESCRIPTION
## Summary

- Adds `mcp/server.lisp` — a standalone MCP stdio server (JSON-RPC 2.0) in Common Lisp
- Uses `jonathan` via Quicklisp for JSON parsing/serialization (Quicklisp is already a Rhema prerequisite)
- Exposes a single `rhema_eval` tool that connects to `/tmp/rhema.sock`, sends the expression, reads the `===RHEMA-BEGIN===`/`===RHEMA-END===` delimited response, and returns it
- Handles MCP methods: `initialize`, `notifications/initialized`, `tools/list`, `tools/call`
- Adds `Makefile` with `build/mcp` target

## Prerequisites

1. SBCL installed
2. Quicklisp installed (`~/.quicklisp/setup.lisp` must exist)
3. Rhema socket server running (`/tmp/rhema.sock`)

## Running

```bash
sbcl --script mcp/server.lisp
```

All debug/startup output goes to `stderr`. `stdout` is clean JSON-RPC only.

## Integration

### VSCode Copilot (agent mode)

Add to `.vscode/mcp.json` in your project (or `~/.vscode/mcp.json` globally):

```json
{
  "servers": {
    "rhema": {
      "type": "stdio",
      "command": "sbcl",
      "args": ["--script", "/path/to/rhema/mcp/server.lisp"]
    }
  }
}
```

Then in VS Code: open the Copilot chat panel → select **Agent** mode → `rhema_eval` will appear in the tool list.

### OpenCode

Add to your `~/.config/opencode/config.json` (or project-local `.opencode/config.json`):

```json
{
  "mcp": {
    "rhema": {
      "type": "local",
      "command": ["sbcl", "--script", "/path/to/rhema/mcp/server.lisp"],
      "enabled": true
    }
  }
}
```

### Claude Desktop / other MCP hosts

Generic config (works for any MCP-compliant host):

```json
{
  "mcpServers": {
    "rhema": {
      "command": "sbcl",
      "args": ["--script", "/path/to/rhema/mcp/server.lisp"]
    }
  }
}
```

## Test plan

- [x] `initialize` returns correct protocolVersion, capabilities, serverInfo
- [x] `notifications/initialized` is silently accepted (no response)
- [x] `tools/list` returns `rhema_eval` with correct inputSchema
- [x] `tools/call` with `rhema_eval` connects to socket, evaluates, returns result
- [x] Unknown methods return `-32601` error
- [x] Socket-down scenario returns `isError: true` with descriptive message
- [x] `make build/mcp` checks for sbcl and prints run command

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)